### PR TITLE
flexquant: rowwise triton template

### DIFF
--- a/flexquant/api.py
+++ b/flexquant/api.py
@@ -6,6 +6,8 @@ from triton_kernels import (
     triton_fp8_blockwise_act_quant_lhs,
     triton_fp8_blockwise_act_quant_transposed_lhs,
     triton_fp8_blockwise_weight_quant_128_128,
+    triton_fp8_rowwise_quant,
+    triton_fp8_rowwise_quant_dim_m,
 )
 
 
@@ -148,19 +150,46 @@ def flex_cast_quant_dense(
     elif n_block_dims == 1 and block_size_t == (-1,):
         # rowwise scaling (entire row is one block)
 
-        assert not use_triton_kernel, "unsupported"
         if normalized_dim_t == (1,):
             # dim=-1: reduce across K; output qdata in (M, K), scale shape (M,)
-            amax = input.abs().amax(dim=-1, keepdim=True)  # (M, 1)
-            scale_bc = amax_to_scale_fn(amax)
-            qdata = cast_to_dtype_fn(input, scale_bc)
-            scale = scale_bc.squeeze(-1)
+            if (
+                use_triton_kernel
+                and qdata_dtype == torch.float8_e4m3fn
+                and scale_dtype == torch.float32
+            ):
+                assert amax_to_scale_fn_triton is not None
+                assert cast_to_dtype_fn_triton is not None
+                qdata, scale = triton_fp8_rowwise_quant(
+                    input, amax_to_scale_fn_triton, cast_to_dtype_fn_triton
+                )
+            else:
+                assert not use_triton_kernel, (
+                    "use_triton_kernel for rowwise dim=-1 only supports fp8_e4m3fn + fp32"
+                )
+                amax = input.abs().amax(dim=-1, keepdim=True)  # (M, 1)
+                scale_bc = amax_to_scale_fn(amax)
+                qdata = cast_to_dtype_fn(input, scale_bc)
+                scale = scale_bc.squeeze(-1)
         elif normalized_dim_t == (0,):
             # dim=-2: reduce across M; output qdata in (K, M), scale shape (K,)
-            amax = input.abs().amax(dim=-2, keepdim=True)  # (1, K)
-            scale_bc = amax_to_scale_fn(amax)
-            qdata = cast_to_dtype_fn(input, scale_bc).transpose(-2, -1).contiguous()
-            scale = scale_bc.squeeze(-2)
+            if (
+                use_triton_kernel
+                and qdata_dtype == torch.float8_e4m3fn
+                and scale_dtype == torch.float32
+            ):
+                assert amax_to_scale_fn_triton is not None
+                assert cast_to_dtype_fn_triton is not None
+                qdata, scale = triton_fp8_rowwise_quant_dim_m(
+                    input, amax_to_scale_fn_triton, cast_to_dtype_fn_triton
+                )
+            else:
+                assert not use_triton_kernel, (
+                    "use_triton_kernel for rowwise dim=-2 only supports fp8_e4m3fn + fp32"
+                )
+                amax = input.abs().amax(dim=-2, keepdim=True)  # (1, K)
+                scale_bc = amax_to_scale_fn(amax)
+                qdata = cast_to_dtype_fn(input, scale_bc).transpose(-2, -1).contiguous()
+                scale = scale_bc.squeeze(-2)
         else:
             raise AssertionError(f"unsupported dim={dim} for rowwise scaling")
 

--- a/flexquant/benchmark.py
+++ b/flexquant/benchmark.py
@@ -13,6 +13,8 @@ from recipes import (
     deepseek_fp8_128_128_triton,
     rowwise_fp8,
     rowwise_fp8_dim_m,
+    rowwise_fp8_dim_m_triton,
+    rowwise_fp8_triton,
 )
 
 B200_PEAK_BW_GBPS = 8000.0  # 8 TB/s
@@ -27,7 +29,9 @@ RECIPES_BY_NAME = {
         deepseek_fp8_128_128,
         deepseek_fp8_128_128_triton,
         rowwise_fp8,
+        rowwise_fp8_triton,
         rowwise_fp8_dim_m,
+        rowwise_fp8_dim_m_triton,
     )
 }
 

--- a/flexquant/recipes.py
+++ b/flexquant/recipes.py
@@ -176,7 +176,8 @@ deepseek_fp8_128_128_triton = Recipe(
 
 
 def _rowwise_fp8_amax_to_scale_fn(amax: torch.Tensor) -> torch.Tensor:
-    return (amax.clamp(min=EPS) / FP8_MAX).to(torch.float32)
+    # fp32-throughout (matches the deepseek family).
+    return amax.clamp(min=EPS).to(torch.float32) / FP8_MAX
 
 
 def _rowwise_fp8_cast_to_dtype_fn(
@@ -186,8 +187,24 @@ def _rowwise_fp8_cast_to_dtype_fn(
     return y.to(torch.float8_e4m3fn)
 
 
+@triton.jit
+def rowwise_fp8_amax_to_scale_fn_triton(amax):
+    EPS: tl.constexpr = 1e-12
+    FP8_MAX_C: tl.constexpr = 448.0
+    amax_fp32 = tl.maximum(amax.to(tl.float32), EPS)
+    return amax_fp32 / FP8_MAX_C
+
+
+@triton.jit
+def rowwise_fp8_cast_to_dtype_fn_triton(tile, scale):
+    y = tile / scale
+    return y.to(tl.float8e4nv)
+
+
 def _rowwise_fp8_reference(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    scale = (x.abs().amax(dim=-1, keepdim=True).clamp(min=EPS) / FP8_MAX).to(torch.float32)
+    # fp32-throughout (matches the deepseek family).
+    amax = x.abs().amax(dim=-1, keepdim=True).clamp(min=EPS).to(torch.float32)
+    scale = amax / FP8_MAX
     qdata = (x / scale).to(torch.float8_e4m3fn)
     return qdata, scale.squeeze(-1)
 
@@ -201,6 +218,20 @@ rowwise_fp8 = Recipe(
     amax_to_scale_fn=_rowwise_fp8_amax_to_scale_fn,
     cast_to_dtype_fn=_rowwise_fp8_cast_to_dtype_fn,
     reference_fn=_rowwise_fp8_reference,
+)
+
+rowwise_fp8_triton = Recipe(
+    name="rowwise_fp8_triton",
+    block_size=-1,
+    dim=-1,
+    qdata_dtype=torch.float8_e4m3fn,
+    scale_dtype=torch.float32,
+    amax_to_scale_fn=_rowwise_fp8_amax_to_scale_fn,
+    cast_to_dtype_fn=_rowwise_fp8_cast_to_dtype_fn,
+    reference_fn=_rowwise_fp8_reference,
+    amax_to_scale_fn_triton=rowwise_fp8_amax_to_scale_fn_triton,
+    cast_to_dtype_fn_triton=rowwise_fp8_cast_to_dtype_fn_triton,
+    use_triton_kernel=True,
 )
 
 
@@ -218,4 +249,18 @@ rowwise_fp8_dim_m = Recipe(
     amax_to_scale_fn=_rowwise_fp8_amax_to_scale_fn,
     cast_to_dtype_fn=_rowwise_fp8_cast_to_dtype_fn,
     reference_fn=_rowwise_fp8_dim_m_reference,
+)
+
+rowwise_fp8_dim_m_triton = Recipe(
+    name="rowwise_fp8_dim_m_triton",
+    block_size=-1,
+    dim=-2,
+    qdata_dtype=torch.float8_e4m3fn,
+    scale_dtype=torch.float32,
+    amax_to_scale_fn=_rowwise_fp8_amax_to_scale_fn,
+    cast_to_dtype_fn=_rowwise_fp8_cast_to_dtype_fn,
+    reference_fn=_rowwise_fp8_dim_m_reference,
+    amax_to_scale_fn_triton=rowwise_fp8_amax_to_scale_fn_triton,
+    cast_to_dtype_fn_triton=rowwise_fp8_cast_to_dtype_fn_triton,
+    use_triton_kernel=True,
 )

--- a/flexquant/test.py
+++ b/flexquant/test.py
@@ -15,6 +15,8 @@ from recipes import (
     deepseek_fp8_128_128_triton,
     rowwise_fp8,
     rowwise_fp8_dim_m,
+    rowwise_fp8_dim_m_triton,
+    rowwise_fp8_triton,
 )
 
 RECIPES = [
@@ -25,7 +27,9 @@ RECIPES = [
     deepseek_fp8_128_128,
     deepseek_fp8_128_128_triton,
     rowwise_fp8,
+    rowwise_fp8_triton,
     rowwise_fp8_dim_m,
+    rowwise_fp8_dim_m_triton,
 ]
 
 

--- a/flexquant/triton_kernels.py
+++ b/flexquant/triton_kernels.py
@@ -263,6 +263,169 @@ def triton_fp8_blockwise_act_quant_transposed_lhs_kernel(
     tl.store(s_ptr + scale_offs, scale, mask=scale_mask)
 
 
+# ----------------------------------------------------------------------------
+# Naive rowwise quant kernel — written from scratch (not adapted from ao).
+# One program per row; two passes over K (amax, then cast). No autotune yet.
+# ----------------------------------------------------------------------------
+
+
+@triton.jit
+def triton_fp8_rowwise_quant_kernel(
+    x_ptr,
+    x_stride_dim_0,
+    x_stride_dim_1,
+    y_ptr,
+    y_stride_dim_0,
+    y_stride_dim_1,
+    s_ptr,
+    M,
+    K: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    amax_to_scale_fn: tl.constexpr,
+    cast_to_dtype_fn: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    if pid_m >= M:
+        return
+
+    # Pass 1: compute amax over the entire row.
+    amax = tl.zeros((), dtype=tl.float32)
+    for k_start in range(0, K, BLOCK_SIZE):
+        k_offs = k_start + tl.arange(0, BLOCK_SIZE)
+        k_mask = k_offs < K
+        offs = pid_m * x_stride_dim_0 + k_offs * x_stride_dim_1
+        x_chunk = tl.load(x_ptr + offs, mask=k_mask, other=0.0)
+        chunk_amax = tl.max(tl.abs(x_chunk))
+        amax = tl.maximum(amax, chunk_amax.to(tl.float32))
+
+    scale = amax_to_scale_fn(amax)
+    tl.store(s_ptr + pid_m, scale)
+
+    # Pass 2: cast each chunk using the scale.
+    for k_start in range(0, K, BLOCK_SIZE):
+        k_offs = k_start + tl.arange(0, BLOCK_SIZE)
+        k_mask = k_offs < K
+        x_offs = pid_m * x_stride_dim_0 + k_offs * x_stride_dim_1
+        x_chunk = tl.load(x_ptr + x_offs, mask=k_mask, other=0.0)
+        y_chunk = cast_to_dtype_fn(x_chunk, scale)
+        y_offs = pid_m * y_stride_dim_0 + k_offs * y_stride_dim_1
+        tl.store(y_ptr + y_offs, y_chunk, mask=k_mask)
+
+
+def triton_fp8_rowwise_quant(
+    x: torch.Tensor,
+    amax_to_scale_fn: Callable,
+    cast_to_dtype_fn: Callable,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert x.dim() == 2, "Input tensor must have 2 dimensions"
+    dtype = torch.float8_e4m3fn
+    M, K = x.size()
+    y = torch.empty_like(x, dtype=dtype)
+    s = x.new_empty(M, dtype=torch.float32)
+
+    # Naive: process the row in 256-element chunks. No autotune.
+    BLOCK_SIZE = 256
+
+    triton_fp8_rowwise_quant_kernel[(M,)](
+        x,
+        x.stride(0),
+        x.stride(1),
+        y,
+        y.stride(0),
+        y.stride(1),
+        s,
+        M,
+        K=K,
+        BLOCK_SIZE=BLOCK_SIZE,
+        amax_to_scale_fn=amax_to_scale_fn,
+        cast_to_dtype_fn=cast_to_dtype_fn,
+    )
+    return y, s
+
+
+# ----------------------------------------------------------------------------
+# Naive rowwise dim_m quant kernel — one program per K column, two passes over
+# M. Output qdata in (K, M) row-major, scale shape (K,). No autotune.
+# ----------------------------------------------------------------------------
+
+
+@triton.jit
+def triton_fp8_rowwise_quant_dim_m_kernel(
+    x_ptr,
+    x_stride_dim_0,
+    x_stride_dim_1,
+    y_ptr,
+    y_stride_dim_0,
+    y_stride_dim_1,
+    s_ptr,
+    M: tl.constexpr,
+    K,
+    BLOCK_SIZE: tl.constexpr,
+    amax_to_scale_fn: tl.constexpr,
+    cast_to_dtype_fn: tl.constexpr,
+):
+    pid_k = tl.program_id(axis=0)
+    if pid_k >= K:
+        return
+
+    # Pass 1: amax across M for column pid_k.
+    amax = tl.zeros((), dtype=tl.float32)
+    for m_start in range(0, M, BLOCK_SIZE):
+        m_offs = m_start + tl.arange(0, BLOCK_SIZE)
+        m_mask = m_offs < M
+        offs = m_offs * x_stride_dim_0 + pid_k * x_stride_dim_1
+        x_chunk = tl.load(x_ptr + offs, mask=m_mask, other=0.0)
+        chunk_amax = tl.max(tl.abs(x_chunk))
+        amax = tl.maximum(amax, chunk_amax.to(tl.float32))
+
+    scale = amax_to_scale_fn(amax)
+    tl.store(s_ptr + pid_k, scale)
+
+    # Pass 2: cast each chunk and write to (K, M) row-major output.
+    for m_start in range(0, M, BLOCK_SIZE):
+        m_offs = m_start + tl.arange(0, BLOCK_SIZE)
+        m_mask = m_offs < M
+        x_offs = m_offs * x_stride_dim_0 + pid_k * x_stride_dim_1
+        x_chunk = tl.load(x_ptr + x_offs, mask=m_mask, other=0.0)
+        y_chunk = cast_to_dtype_fn(x_chunk, scale)
+        # Output is (K, M) row-major: row pid_k, column m_offs.
+        y_offs = pid_k * y_stride_dim_0 + m_offs * y_stride_dim_1
+        tl.store(y_ptr + y_offs, y_chunk, mask=m_mask)
+
+
+def triton_fp8_rowwise_quant_dim_m(
+    x: torch.Tensor,
+    amax_to_scale_fn: Callable,
+    cast_to_dtype_fn: Callable,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert x.dim() == 2, "Input tensor must have 2 dimensions"
+    dtype = torch.float8_e4m3fn
+    M, K = x.size()
+    y = torch.empty(K, M, dtype=dtype, device=x.device)  # row-major (K, M)
+    s = x.new_empty(K, dtype=torch.float32)
+
+    # Naive: process the column in 256-element chunks. No autotune.
+    BLOCK_SIZE = 256
+
+    triton_fp8_rowwise_quant_dim_m_kernel[(K,)](
+        x,
+        x.stride(0),
+        x.stride(1),
+        y,
+        y.stride(0),
+        y.stride(1),
+        s,
+        M=M,
+        K=K,
+        BLOCK_SIZE=BLOCK_SIZE,
+        amax_to_scale_fn=amax_to_scale_fn,
+        cast_to_dtype_fn=cast_to_dtype_fn,
+    )
+    return y, s
+
+
 def triton_fp8_blockwise_act_quant_transposed_lhs(
     x: torch.Tensor,
     amax_to_scale_fn: Callable,


### PR DESCRIPTION
Summary:

kernels 100% clauded with no perf optimizations, that's for later

Test Plan: