### PR TITLE
add nvfp4 without global scale

### DIFF
--- a/flexquant/api.py
+++ b/flexquant/api.py
@@ -35,7 +35,9 @@ def flex_cast_quant_dense(
     callbacks: how to turn a tile's amax into a scale, and how to cast a tile
     given its scale.
 
-    Tiles are defined by ``block_size`` and ``dim``. Supported shapes:
+    Tiles are defined by ``block_size`` and ``dim``. Supported shapes
+    (logical element counts; sub-byte qdata dtypes pack multiple values per
+    byte, see below):
 
     - **1D blocked**: ``block_size: int``, ``dim: int``
       - dim=-1: output qdata is `(M, K)`, scale is `(M, K // block_size)`
@@ -43,6 +45,13 @@ def flex_cast_quant_dense(
 
     - **2D blocked** ``block_size: tuple[int, int]``, ``dim=(-2, -1)``
       - qdata is `(M, K)`, scale is `(M // B1, K // B2)`.
+
+    Sub-byte qdata dtypes (currently ``torch.float4_e2m1fn_x2``) pack two
+    values per byte along the innermost dim, so the returned qdata's
+    ``shape[-1]`` is half the logical K. TODO(future): generalize this by
+    exposing a ``qdata_bits_per_element`` argument and computing
+    ``qdata_pack_factor = 8 // bits``. The current dtype-specific branch
+    only handles ``float4_e2m1fn_x2``.
 
     Args:
         input: 2D contiguous tensor.
@@ -72,6 +81,14 @@ def flex_cast_quant_dense(
     normalized_dim_t = tuple(d if d >= 0 else d + input.ndim for d in dim_t)
     M, K = input.shape
 
+    # Sub-byte qdata dtypes pack multiple values per byte and shrink the
+    # logical element count along the innermost dim of cast_to_dtype_fn's
+    # output.
+    if qdata_dtype == torch.float4_e2m1fn_x2:
+        qdata_pack_factor = 2  # 2 fp4 elements per byte
+    else:
+        qdata_pack_factor = 1
+
     # TODO(future):
     # * scale swizzling
     # * padding and other edge cases
@@ -95,7 +112,7 @@ def flex_cast_quant_dense(
             amax = x_b.abs().amax(dim=-1, keepdim=True)  # (M, n_blocks, 1)
             scale_bc = amax_to_scale_fn(amax)
             qdata_b = cast_to_dtype_fn(x_b, scale_bc)
-            qdata = qdata_b.reshape(M, K)
+            qdata = qdata_b.reshape(M, K // qdata_pack_factor)
             scale = scale_bc.squeeze(-1)
 
         else:
@@ -106,6 +123,14 @@ def flex_cast_quant_dense(
                 f"input.shape[-2]={M} must be divisible by block_size={block_size_int}"
             )
 
+            # Packing happens along the inner dim (K), and this path transposes
+            # to (K, M) layout, which would have to swap bytes whose two fp4
+            # halves are K-adjacent. Not supported yet.
+            # TODO(future PR): add support for this in the reference path.
+            assert qdata_pack_factor == 1, (
+                "sub-byte qdata dtypes are not supported on the dim=-2 path"
+            )
+
             # hop known fast, use it unless overridden
             _use_hop_path = _hop_mode in (_HopMode.AUTO, _HopMode.HOP)
 
@@ -114,6 +139,7 @@ def flex_cast_quant_dense(
                     block_size_int == 128 
                     and qdata_dtype == torch.float8_e4m3fn 
                     and scale_dtype == torch.float32
+                    and qdata_pack_factor == 1
                 ), "unsupported"
                 qdata, scale = flex_cast_quant_dense_with_hop(
                     input,
@@ -152,6 +178,7 @@ def flex_cast_quant_dense(
                     (B1, B2) == (128, 128)
                     and qdata_dtype == torch.float8_e4m3fn
                     and scale_dtype == torch.float32
+                    and qdata_pack_factor == 1
                 ), "unsupported"
                 qdata, scale = flex_cast_quant_dense_with_hop(
                     input,
@@ -177,10 +204,10 @@ def flex_cast_quant_dense(
                 scale_bc = amax_to_scale_fn(amax)
                 qdata_b = cast_to_dtype_fn(x_b, scale_bc)
                 qdata = (
-                    qdata_b.reshape(n1, n2, B1, B2)
+                    qdata_b.reshape(n1, n2, B1, B2 // qdata_pack_factor)
                     .transpose(-3, -2)
                     .contiguous()
-                    .reshape(M, K)
+                    .reshape(M, K // qdata_pack_factor)
                 )
                 scale = scale_bc.squeeze(-1)
 

--- a/flexquant/nvfp4_utils.py
+++ b/flexquant/nvfp4_utils.py
@@ -1,0 +1,301 @@
+# Numerical helpers for nvfp4 quantization.
+#
+# `_f32_to_floatx_unpacked` / `_floatx_unpacked_to_f32` are copied verbatim from
+# torchao (`/home/dev/ao/torchao/prototype/custom_fp_utils.py`).
+# `f32_to_f4_unpacked` / `f4_unpacked_to_f32` are copied from
+# `/home/dev/ao/torchao/prototype/mx_formats/kernels.py`.
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This script was initially developed for sub-byte MX dtypes (FP4 E2M1, FP6 E3M2, and FP6 E2M3).
+# It has been refactored to support any sub-byte FP dtypes. However, some behaviors of MX dtypes remain:
+#   1. No encodings are reserved for special values (+/-inf, NaN).
+#   2. When downcasting from FP32 to Floatx,
+#      - Rounding mode is round to nearest, ties to even.
+#      - Values outside the representable range of Floatx after rounding are clamped to the maximum Floatx
+#      magnitude (sign is preserved).
+
+import torch
+from torch import Tensor
+
+
+def _n_ones(n: int) -> int:
+    return (1 << n) - 1
+
+
+EBITS_F32, MBITS_F32 = 8, 23
+F32_EXP_BIAS = _n_ones(EBITS_F32 - 1)
+
+EBITS_F4_E2M1, MBITS_F4_E2M1 = 2, 1
+F4_E2M1_MAX = 6.0
+
+
+def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
+    """Convert FP32 numbers to sub-byte floating point numbers with the given
+    number of exponent and mantissa bits.
+
+    Input: torch.Tensor of dtype torch.float
+    Output: torch.Tensor of dtype torch.uint8, where the bit encoding is stored
+    in the least significant bits. e.g.
+      fp4: bits 0-3 empty and bits 4-7 in fp4_e2m1 encoding
+      fp6: bits 0-1 empty and bits 2-7 in fp6_e2m3 or fp6_e3m2 encoding
+
+    Note: there are no special values (NaN, inf) support in this code. Values
+    outside the representable range of Floatx after rounding are clamped to the
+    maximum Floatx magnitude (sign is preserved).
+
+    Code below is an adaptation of https://fburl.com/code/ciwofcg4
+
+    Background 1: last answer in https://stackoverflow.com/questions/8981913/how-to-perform-round-to-even-with-floating-point-numbers  # noqa: E501
+    Background 2: Computer Organization and Design, RISC-V edition, Chapter 3.5
+    """
+    assert x.dtype == torch.float
+    assert 1 + ebits + mbits <= 8
+
+    # calculate constants
+    exp_bias = _n_ones(ebits - 1)
+    max_int = _n_ones(ebits + mbits)
+    sign_mask = 1 << (ebits + mbits)
+
+    # TODO document this better
+    magic_adder = _n_ones(MBITS_F32 - mbits - 1)
+
+    # all E bits and M bits are 1s
+    max_normal = 2 ** (_n_ones(ebits) - exp_bias) * (_n_ones(mbits + 1) / (2**mbits))
+
+    # E bits = 1, M bits = 0
+    min_normal = 2 ** (1 - exp_bias)
+
+    denorm_exp = (
+        # exp bias conversion between formats
+        (F32_EXP_BIAS - exp_bias)
+        # mantissa length difference between formats
+        + (MBITS_F32 - mbits)
+        # add one to encoded exponent for denormalized numbers
+        + 1
+    )
+    denorm_mask_int = denorm_exp << MBITS_F32
+
+    # reinterpret int32 as float32
+    denorm_mask_float = torch.tensor(denorm_mask_int, dtype=torch.int32).view(
+        torch.float32
+    )
+
+    # save the sign
+    # Note that we have torch.uint32, but some ops like cpu bit shifts
+    # do not work on it. So, we stay in int32.
+    x = x.view(torch.int32)
+    sign = x & 0x80000000
+
+    # set everything to positive, will add sign back at the end
+    x = x ^ sign
+
+    # TODO: can the branch floating point comparisons below be done without
+    # converting to float? probably but need to verify
+    x = x.view(torch.float)
+
+    # rewrite saturate/denorm/norm branches without explicit data dependent
+    # control flow, to be more compiler friendly
+    saturate_mask = x >= max_normal
+    denormal_mask = torch.logical_and(torch.logical_not(saturate_mask), x < min_normal)
+    normal_mask = torch.logical_not(torch.logical_or(saturate_mask, denormal_mask))
+
+    #
+    # branch 1: saturate to max val - handled later in the code which combines
+    #   the branches
+    #
+
+    #
+    # branch 2: to conversion to denormal as well as rounding up to normal
+    #
+    denormal_x = x + denorm_mask_float
+    denormal_x = denormal_x.view(torch.int32)
+    denormal_x -= denorm_mask_int
+    denormal_x = denormal_x.to(torch.uint8)
+
+    #
+    # branch 3: stay in normal range, adjust the exponent and round
+    #
+    normal_x = x.view(torch.int32)
+    # resulting mantissa is odd
+    mant_odd = (normal_x >> (MBITS_F32 - mbits)) & 1
+    # update exponent, rounding bias part 1
+    val_to_add = ((exp_bias - F32_EXP_BIAS) << MBITS_F32) + magic_adder
+    normal_x += val_to_add
+    # rounding bias part 2
+    normal_x += mant_odd
+    # take the bits!
+    normal_x = normal_x >> (MBITS_F32 - mbits)
+    normal_x = normal_x.to(torch.uint8)
+
+    #
+    # combine the branches
+    #
+    x = torch.full_like(x, max_int, dtype=torch.uint8)
+    x = torch.where(denormal_mask, denormal_x, x)
+    x = torch.where(normal_mask, normal_x, x)
+
+    # add sign back
+    sign_lp = sign >> (MBITS_F32 + EBITS_F32 - mbits - ebits)
+    sign_lp = sign_lp.to(torch.uint8)
+    # Right shift of a negative signed integer can fill the least significant
+    # bits with either 1s or 0s, depending on the implementation. Since PyTorch
+    # doesn't have an uint32 dtype, we mask out these bits to get just the
+    # f4 sign bit
+    sign_lp = sign_lp & sign_mask
+    x = x | sign_lp
+
+    return x.to(torch.uint8)
+
+
+# TODO(future): check if LUT for everything is faster than bit shifting,
+# especially for fp4 (only 2^4=16 unique values).
+def _floatx_unpacked_to_f32(x: Tensor, ebits: int, mbits: int) -> Tensor:
+    """Convert sub-byte floating point numbers with the given number of exponent
+    and mantissa bits to FP32.
+
+    Input: torch.Tensor of dtype uint8, where the bit encoding is stored
+    in the least significant bits. e.g.
+      fp4: bits 0-3 empty and bits 4-7 in fp4_e2m1 encoding
+      fp6: bits 0-1 empty and bits 2-7 in fp6_e2m3 or fp6_e3m2 encoding
+    Output: torch.Tensor of dtype fp32 with the dequantized value
+    """
+    assert x.dtype == torch.uint8
+    assert 1 + ebits + mbits <= 8
+
+    sign_mask = 1 << (ebits + mbits)
+    exp_bias = _n_ones(ebits - 1)
+    mantissa_mask = _n_ones(mbits)
+
+    # save the sign
+    sign_lp = x & sign_mask
+
+    # set everything to positive, will add sign back at the end
+    x_pos = x ^ sign_lp
+
+    #
+    # 1. Calculate zero mask
+    #
+    zero_mask = x_pos == 0
+
+    #
+    # 2. Calculate the denormal path mask
+    #
+    denormal_mask = torch.logical_and((x_pos > 0), ((x_pos >> mbits) == 0))
+
+    #
+    # 3. Calculate the normal path
+    #
+
+    # calculate the new exponent and shift it to bits 2:9 of the result
+    exp_biased_lp = x_pos >> mbits
+    exp_biased_f32 = exp_biased_lp - exp_bias + F32_EXP_BIAS
+    exp_biased_f32 = exp_biased_f32.to(torch.int32) << MBITS_F32
+
+    # shift the mantissa to bits 10:32 of the result
+    mantissa_lp_int32 = (x_pos & mantissa_mask).to(torch.int32)
+    mantissa_f32 = mantissa_lp_int32 << (MBITS_F32 - mbits)
+    result = exp_biased_f32 | mantissa_f32
+
+    #
+    # 4. Add the zero and denormal casts to the already casted normal path
+    #
+    result[zero_mask] = 0
+
+    denormal_exp_biased = 1 - exp_bias + F32_EXP_BIAS
+
+    # fast path.
+    # without this, performance for FP4_E2M1 is slower by 2x
+    if mbits == 1:
+        result[denormal_mask] = (denormal_exp_biased - mbits) << MBITS_F32
+
+    else:
+        # iterate over all possible values of mantissa
+        # i=0, j=1
+        # i=1, j=10,11
+        # i=2, j=100,101,110,111
+        # and so on
+        for i in range(mbits):
+            for mantissa_cmp in range(1 << i, 1 << (i + 1)):
+                # left shift mantissa until it overflows (create an implicit 1)
+                # subtract exponent by the same amount
+                left_shift = mbits - i
+                mantissa_f32 = (mantissa_cmp - (1 << i)) << (
+                    left_shift + MBITS_F32 - mbits
+                )
+                exp_biased_f32 = (denormal_exp_biased - left_shift) << MBITS_F32
+
+                # we can update this in-place since the values won't overlap
+                # torch.compile() may complain unsupported operand type(s) for |: 'SymInt' and 'int'
+                # thus we use + instead of | here
+                mantissa_lp_int32[mantissa_lp_int32 == mantissa_cmp] = (
+                    exp_biased_f32 + mantissa_f32
+                )
+
+        result = torch.where(denormal_mask, mantissa_lp_int32, result)
+
+    # add sign back
+    sign_f32 = sign_lp.to(torch.int32) << (MBITS_F32 - mbits + EBITS_F32 - ebits)
+    result = result | sign_f32
+
+    return result.view(torch.float)
+
+
+def f32_to_f4_unpacked(x: Tensor) -> Tensor:
+    """
+    Input: torch.Tensor of dtype torch.float
+    Output: torch.Tensor of dtype torch.uint8, with bits 0-3 empty and
+      bits 4-7 in fp4_e2m1
+    """
+    return _f32_to_floatx_unpacked(x, EBITS_F4_E2M1, MBITS_F4_E2M1)
+
+
+def f4_unpacked_to_f32(x: Tensor) -> Tensor:
+    """
+    Input: torch.Tensor of dtype uint8, with bits 0-3 empty and bits 4-7
+      containing an fp4_e2m1 encoding
+    Output: torch.Tensor of dtype fp32 with the dequantized value
+    """
+    return _floatx_unpacked_to_f32(x, EBITS_F4_E2M1, MBITS_F4_E2M1)
+
+
+# pack/unpack code copy-pasted from
+# https://github.com/pytorch-labs/ao/blob/main/torchao/dtypes/uint4.py
+
+
+def down_size(size):
+    assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
+    return (*size[:-1], size[-1] // 2)
+
+
+def up_size(size):
+    return (*size[:-1], size[-1] * 2)
+
+
+def unpack_uint4(uint8_data: Tensor) -> Tensor:
+    """Get the original weight from the normalized float weight format"""
+    assert uint8_data.is_contiguous()
+
+    shape = uint8_data.shape
+
+    # since we are using uint8 we will decode 2 entries per byte
+    # Shift elements down 4 and select out the bottom 4 bits
+    first_elements = (uint8_data & 0b1111).to(torch.uint8)
+    second_elements = (uint8_data >> 4).to(torch.uint8)
+    unpacked = torch.stack([first_elements, second_elements], dim=-1).view(
+        up_size(shape)
+    )
+
+    return unpacked
+
+
+def pack_uint4(uint8_data: Tensor) -> Tensor:
+    # converting to uint8 for operations
+    shape = uint8_data.shape
+    assert shape[-1] % 2 == 0
+    uint8_data = uint8_data.contiguous().view(-1)
+    return (uint8_data[::2] | uint8_data[1::2] << 4).view(down_size(shape))

--- a/flexquant/recipes.py
+++ b/flexquant/recipes.py
@@ -3,8 +3,13 @@ from typing import Callable
 
 import torch
 
+from nvfp4_utils import F4_E2M1_MAX, f32_to_f4_unpacked, pack_uint4
+
 FP8_MAX = torch.finfo(torch.float8_e4m3fn).max  # 448.0
 EPS = 1e-12
+
+F8E4M3_MAX = FP8_MAX
+E4M3_EPS = torch.finfo(torch.float8_e4m3fn).tiny
 
 
 @dataclass(frozen=True)
@@ -109,5 +114,52 @@ deepseek_fp8_128_128 = Recipe(
     amax_to_scale_fn=_deepseek_fp8_amax_to_scale_fn,
     cast_to_dtype_fn=_deepseek_fp8_cast_to_dtype_fn,
     _reference_fn=_deepseek_fp8_128_128_reference,
+)
+
+
+# nvfp4 with single-level scaling and packed fp4 (two fp4 values per byte,
+# stored as torch.float4_e2m1fn_x2). Mirrors the `per_tensor_scale is None`
+# branch of `nvfp4_quantize` in torchao.
+
+def _nvfp4_amax_to_scale_fn(amax: torch.Tensor) -> torch.Tensor:
+    block_scale = amax.to(torch.float32) / F4_E2M1_MAX
+    return torch.clamp(block_scale, min=E4M3_EPS, max=F8E4M3_MAX).to(
+        torch.float8_e4m3fn
+    )
+
+
+def _nvfp4_cast_to_dtype_fn(
+    tile: torch.Tensor, scale: torch.Tensor
+) -> torch.Tensor:
+    scale_fp32 = scale.to(torch.float32)
+    data_scaled = tile.to(torch.float32) * (1.0 / scale_fp32)
+    data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
+    data_unpacked = f32_to_f4_unpacked(data_scaled)
+    return pack_uint4(data_unpacked).view(torch.float4_e2m1fn_x2)
+
+
+def _nvfp4_no_gs_reference(
+    x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    *lead, last = x.shape
+    n_blocks = last // 16
+    x_b = x.reshape(*lead, n_blocks, 16)
+    amax = x_b.abs().amax(dim=-1, keepdim=True)
+    scale_e4m3 = _nvfp4_amax_to_scale_fn(amax)
+    qdata_b = _nvfp4_cast_to_dtype_fn(x_b, scale_e4m3)
+    # qdata_b shape: (*lead, n_blocks, 8) packed -> (*lead, last // 2)
+    qdata = qdata_b.reshape(*lead, last // 2)
+    return qdata, scale_e4m3.squeeze(-1)
+
+
+nvfp4_no_gs = Recipe(
+    name="nvfp4_no_gs",
+    block_size=16,
+    dim=-1,
+    qdata_dtype=torch.float4_e2m1fn_x2,
+    scale_dtype=torch.float8_e4m3fn,
+    amax_to_scale_fn=_nvfp4_amax_to_scale_fn,
+    cast_to_dtype_fn=_nvfp4_cast_to_dtype_fn,
+    _reference_fn=_nvfp4_no_gs_reference,
 )
 

--- a/flexquant/test.py
+++ b/flexquant/test.py
@@ -16,6 +16,7 @@ from recipes import (
     deepseek_fp8_1_128,
     deepseek_fp8_1_128_dim_m,
     deepseek_fp8_128_128,
+    nvfp4_no_gs,
 )
 
 # (label, recipe, hop_mode). Recipes that support both HOP and non-HOP routes
@@ -26,6 +27,7 @@ RECIPES_PT: list[tuple[str, Recipe, _HopMode]] = [
     ("deepseek_fp8_1_128_dim_m_hop", deepseek_fp8_1_128_dim_m, _HopMode.HOP),
     ("deepseek_fp8_128_128", deepseek_fp8_128_128, _HopMode.NO_HOP),
     ("deepseek_fp8_128_128_hop", deepseek_fp8_128_128, _HopMode.HOP),
+    ("nvfp4_no_gs", nvfp4_no_gs, _HopMode.NO_HOP),
 ]
 RECIPES_TRITON: list[tuple[str, RecipeTriton]] = [
     ("deepseek_fp8_1_128_dim_m_triton", deepseek_fp8_1_128_dim_m_triton),
@@ -69,7 +71,12 @@ def test_pt_eager_vs_reference(label: str, recipe: Recipe, hop_mode: _HopMode):
     qdata, scale = _call_pt(recipe, hop_mode, x)
     qdata_ref, scale_ref = recipe._reference_fn(x)
 
-    assert torch.equal(qdata.to(torch.float32), qdata_ref.to(torch.float32))
+    if qdata.dtype == torch.float4_e2m1fn_x2:
+        # `.to(torch.float32)` isn't implemented for float4_e2m1fn_x2; compare
+        # the underlying packed bytes instead.
+        assert torch.equal(qdata.view(torch.uint8), qdata_ref.view(torch.uint8))
+    else:
+        assert torch.equal(qdata.to(torch.float32), qdata_ref.to(torch.float32))
     assert torch.equal(scale, scale_ref)
 
 
@@ -102,10 +109,22 @@ def test_eager_vs_compile(label: str, recipe: Recipe, hop_mode: _HopMode):
     # Inductor may reorder fp ops, causing tiny scale drift that flips a small
     # fraction of fp8 values by one quantization bin. Compare with tolerances
     # that accept one-bin drift but not algorithmic divergence.
-    torch.testing.assert_close(scale_eager, scale_compiled, rtol=1e-2, atol=1e-6)
-    bin_flip_frac = (
-        qdata_eager.to(torch.float32) != qdata_compiled.to(torch.float32)
-    ).float().mean().item()
+    # Cast scale to fp32 for comparison: assert_close with tolerances doesn't
+    # support fp8 dtypes (e.g. nvfp4 uses e4m3 scale).
+    torch.testing.assert_close(
+        scale_eager.to(torch.float32),
+        scale_compiled.to(torch.float32),
+        rtol=1e-2,
+        atol=1e-6,
+    )
+    if qdata_eager.dtype == torch.float4_e2m1fn_x2:
+        # `.to(torch.float32)` isn't implemented for float4_e2m1fn_x2; compare
+        # packed bytes. Note this is stricter than per-element compare since
+        # one byte mismatch covers two fp4 elements.
+        diff = qdata_eager.view(torch.uint8) != qdata_compiled.view(torch.uint8)
+    else:
+        diff = qdata_eager.to(torch.float32) != qdata_compiled.to(torch.float32)
+    bin_flip_frac = diff.float().mean().item()
     assert bin_flip_frac < 0.05, f"too many bin flips: {bin_flip_frac}"
 
 


### PR DESCRIPTION
Summary:

add nvfp4 reference, with packing to fp4, across dim==-1 skip global scale for now (next PR)
skip generalized packing for now
skip dim==-2 and 2d blocks for now

Test Plan: